### PR TITLE
Images upload

### DIFF
--- a/client/textboxes/content-editable/content-editable-controller.coffee
+++ b/client/textboxes/content-editable/content-editable-controller.coffee
@@ -177,6 +177,10 @@ class Ctrls.ContentEditable extends AutoRun
 
     # Paste AFTER medium-js has handled the paste.
     el.on 'paste', (e) =>
+        # bubbles paste:image event when trying to paste images
+        if (e.originalEvent.clipboardData?.types?.any (t) -> t is 'Files')
+          bubble 'paste:image', e
+
         userAgent = UserAgent.current
         wasChanged = false
 

--- a/client/textboxes/content-editable/ctrl/content-editable.coffee
+++ b/client/textboxes/content-editable/ctrl/content-editable.coffee
@@ -58,6 +58,7 @@ Ctrl.define
       bubble('changed')
       bubble('key:enter')
       bubble('key:esc')
+      bubble('paste:image')
 
       # Handle events.
       @textbox.on 'focus', (j,e) => @find().addClass 'focused'

--- a/client/textboxes/content-editable/lib/js/medium-editor.js
+++ b/client/textboxes/content-editable/lib/js/medium-editor.js
@@ -1,5 +1,6 @@
 // This is not the vanilla MediumEditor - one line has been changed
-// to fix pasting in windows. (Line 1076 at time of writing)
+// to fix pasting in windows. (Line 1076, at time of writing)
+// to fix inserting an empty line when pasting images ( 1101 and 1088 )
 
 function MediumEditor(elements, options) {
     'use strict';
@@ -1085,7 +1086,10 @@ if (typeof module === 'object') {
                             } else {
                                 // Insert empty line.
                                 // See: https://github.com/daviferreira/medium-editor/issues/211
-                                html += '<p><br></p>'
+                                // Emiliano: disabling pasting when trying to paste images
+                                if (clipboardData.items.length === 0) {
+                                    html += '<p><br></p>'
+                                }
                             }
                         }
 
@@ -1095,7 +1099,7 @@ if (typeof module === 'object') {
                         //      http://stackoverflow.com/questions/6690752/insert-html-at-caret-in-a-contenteditable-div/6691294#6691294
                         if (self.isIE) {
                             console.log( 'PASTING NOT WORKIGN IN IE :: ', html );
-                        } else {
+                        } else if (html.length) {
                             document.execCommand('insertHTML', false, html);
                         }
 

--- a/client/textboxes/content-editable/lib/js/medium-editor.js
+++ b/client/textboxes/content-editable/lib/js/medium-editor.js
@@ -1087,7 +1087,7 @@ if (typeof module === 'object') {
                                 // Insert empty line.
                                 // See: https://github.com/daviferreira/medium-editor/issues/211
                                 // Emiliano: disabling pasting when trying to paste images
-                                if (clipboardData.items.length === 0) {
+                                if (clipboardData.items && clipboardData.items.length === 0) {
                                     html += '<p><br></p>'
                                 }
                             }


### PR DESCRIPTION
fixes creating an empty new line when pasting images and triggers `paste:image` when an image has been pasted